### PR TITLE
Adapt for Emscripten 2.0 change of default behaviour for archives

### DIFF
--- a/src/tools/emscripten.jam
+++ b/src/tools/emscripten.jam
@@ -94,7 +94,7 @@ actions compile.c++
 
 actions archive
 {
-    "$(CONFIG_COMMAND)" $(AROPTIONS) -o "$(<)" "$(>)"
+    "$(CONFIG_COMMAND)" $(AROPTIONS) -r -o "$(<)" "$(>)"
 }
 
 toolset.flags emscripten.link USER_OPTIONS <linkflags> ;


### PR DESCRIPTION
When building archives Emscripten 2.0 requires the usage of the `-r` in order to create an archive and not link an executable.